### PR TITLE
Change parameter name in the launch file

### DIFF
--- a/launch/webcam_laserscan.launch.py
+++ b/launch/webcam_laserscan.launch.py
@@ -38,8 +38,7 @@ def generate_launch_description():
 
         Node(
             package='depthimage_to_laserscan',
-            node_executable='depthimage_to_laserscan_node',
-            node_name='depthimage_to_laserscan_node',
+            executable='depthimage_to_laserscan_node',
             remappings=[('depth','/depth/image_raw'),
                         ('depth_camera_info', '/depth/camera_info'),
                         ('scan', '/scan')],


### PR DESCRIPTION
Fix the launch file crash by changing parameter names.